### PR TITLE
Adds support for VAULT_ADDR environment variable and vault_addr confi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Vaultex
+# :lock: Vaultex
 
 [![Hex.pm](https://img.shields.io/hexpm/v/vaultex.svg)]()
 [![Hex.pm](https://img.shields.io/hexpm/dt/vaultex.svg)]()
@@ -38,6 +38,17 @@ Or application variables:
 * `:vaultex, :scheme`
 
 These default to `localhost`, `8200`, `http` respectively.
+
+:new: :newspaper:
+As an alternative to the above, you can configure your vault endpoint with a single environment variable:
+
+* `VAULT_ADDR`
+
+Or a single application variable:
+
+* `:vaultex, :vault_addr`
+
+An example value for VAULT_ADDR is http://127.0.0.1:8200  
 
 
 ## Usage

--- a/lib/vaultex/client.ex
+++ b/lib/vaultex/client.ex
@@ -13,7 +13,7 @@ defmodule Vaultex.Client do
   end
 
   def init(state) do
-    url = "#{get_env(:scheme)}://#{get_env(:host)}:#{get_env(:port)}/#{@version}/"
+    url = "#{scheme}://#{host}:#{port}/#{@version}/"
     {:ok, Map.merge(state, %{url: url})}
   end
 
@@ -86,6 +86,22 @@ defmodule Vaultex.Client do
     Auth.handle(method, credentials, state)
   end
 
+  defp host do
+    parsed_vault_addr.host || get_env(:host)
+  end
+
+  defp port do
+    parsed_vault_addr.port || get_env(:port)
+  end
+
+  defp scheme do
+    parsed_vault_addr.scheme || get_env(:scheme)
+  end
+
+  defp parsed_vault_addr do
+    get_env(:vault_addr) |> to_string |> URI.parse
+  end
+
   defp get_env(:host) do
     System.get_env("VAULT_HOST") || Application.get_env(:vaultex, :host) || "localhost"
   end
@@ -96,5 +112,9 @@ defmodule Vaultex.Client do
 
   defp get_env(:scheme) do
       System.get_env("VAULT_SCHEME") || Application.get_env(:vaultex, :scheme) || "http"
+  end
+
+  defp get_env(:vault_addr) do
+    System.get_env("VAULT_ADDR") || Application.get_env(:vaultex, :vault_addr)
   end
 end


### PR DESCRIPTION
…g. I think the benefits of this proposed change are supporting the canonical environment variable that Hashicorp uses for its official vault cli (see https://www.vaultproject.io/intro/getting-started/dev-server.html) and various clients such as https://github.com/hashicorp/vault-ruby