### PR TITLE
Add SSL_SKIP_VERIFY option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Or application variables:
 
 These default to `localhost`, `8200`, `http` respectively.
 
+You can skip SSL certificate verification with `:vaultex, ssl_skip_verify: true` option
+or `SSL_SKIP_VERIFY=true` environment variable.  
+
 ## Usage
 
 To read a secret you must provide the path to the secret and the authentication backend and credentials you will use to login. See the [Vaultex.Client.auth/2](https://hexdocs.pm/vaultex/Vaultex.Client.html#auth/2) docs for supported auth backends.

--- a/lib/vaultex/client.ex
+++ b/lib/vaultex/client.ex
@@ -74,7 +74,7 @@ defmodule Vaultex.Client do
     end
   end
 
-  defp read(key) do
+  def read(key) do
     GenServer.call(:vaultex, {:read, key})
   end
 

--- a/lib/vaultex/client.ex
+++ b/lib/vaultex/client.ex
@@ -74,7 +74,7 @@ defmodule Vaultex.Client do
     end
   end
 
-  def read(key) do
+  defp read(key) do
     GenServer.call(:vaultex, {:read, key})
   end
 

--- a/lib/vaultex/redirectable_requests.ex
+++ b/lib/vaultex/redirectable_requests.ex
@@ -3,8 +3,10 @@ defmodule Vaultex.RedirectableRequests do
   # the config files in Vaultex appear to be ignored.
   @httpoison Application.get_env(:vaultex, :httpoison) || HTTPoison
 
-  def request(method, url, params = %{}, headers) do
-    @httpoison.request(method, url, Poison.Encoder.encode(params, []), headers)
+  def request(method, url, params = %{}, headers, options \\ []) do
+    options = if ssl_skip_verify?(), do: [{:hackney, [:insecure]} | options], else: options
+
+    @httpoison.request(method, url, Poison.Encoder.encode(params, []), headers, options)
     |> follow_redirect(method, params, headers)
   end
 
@@ -32,5 +34,9 @@ defmodule Vaultex.RedirectableRequests do
 
   defp follow_redirect({:ok, response}, _method, _params, _headers, _status_code) do
     {:ok, response}
+  end
+
+  defp ssl_skip_verify?() do
+    System.get_env("SSL_SKIP_VERIFY") || Application.get_env(:vaultex, :ssl_skip_verify) || false
   end
 end


### PR DESCRIPTION
Added ability to skip SSL certificate verification, e.g. for development with self-signed certificates.

Either:
```
config :vaultex, ssl_skip_verify: true
```

Or:
`SSL_SKIP_VERIFY=true` env variable