### PR TITLE
Fix error reporting reason

### DIFF
--- a/lib/test_doubles/mock_httpoison.ex
+++ b/lib/test_doubles/mock_httpoison.ex
@@ -37,6 +37,7 @@ defmodule Vaultex.Test.TestDoubles.MockHTTPoison do
                                                  headers: [{"Location", redirect_url(url)}],
                                                  body: Poison.Encoder.encode(%{"auth" => %{"client_token" => "mytoken"}}, [])}}
       key |> String.contains?("boom") -> {:error, %HTTPoison.Error{id: nil, reason: :econnrefused}}
+      key |> String.contains?("ssl") -> {:error, %HTTPoison.Error{id: nil, reason: {:tls_alert, 'unknown ca'}}}
       :else -> {:ok, %{body: Poison.Encoder.encode(%{errors: ["Not Authenticated"] }, [])}}
     end
   end

--- a/lib/vaultex/auth.ex
+++ b/lib/vaultex/auth.ex
@@ -38,7 +38,7 @@ defmodule Vaultex.Auth do
   end
 
   defp handle_response({_, %HTTPoison.Error{reason: reason}}, state) do
-    {:reply, {:error, ["Bad response from vault [#{state.url}]", "#{reason}"]}, state}
+    {:reply, {:error, ["Bad response from vault [#{state.url}]", reason]}, state}
   end
 
   defp request(method, url, params = %{}, headers) do

--- a/lib/vaultex/read.ex
+++ b/lib/vaultex/read.ex
@@ -18,7 +18,7 @@ defmodule Vaultex.Read do
   end
 
   defp handle_response({_, %HTTPoison.Error{reason: reason}}, state) do
-      {:reply, {:error, ["Bad response from vault [#{state.url}]", "#{reason}"]}, state}
+      {:reply, {:error, ["Bad response from vault [#{state.url}]", reason]}, state}
   end
 
   defp request(method, url, params = %{}, headers) do

--- a/lib/vaultex/write.ex
+++ b/lib/vaultex/write.ex
@@ -22,7 +22,7 @@ defmodule Vaultex.Write do
   end
 
   defp handle_response({_, %HTTPoison.Error{reason: reason}}, state) do
-    {:reply, {:error, ["Bad response from vault [#{state.url}]", "#{reason}"]}, state}
+    {:reply, {:error, ["Bad response from vault [#{state.url}]", reason]}, state}
   end
 
   defp request(method, url, body, headers) do

--- a/test/vaultex_test.exs
+++ b/test/vaultex_test.exs
@@ -23,7 +23,7 @@ defmodule VaultexTest do
   end
 
   test "Authentication of app_id and user_id causes an exception" do
-    assert Vaultex.Client.auth(:app_id, {"boom", "whatever"}) == {:error, ["Bad response from vault [http://localhost:8200/v1/]", "econnrefused"]}
+    assert Vaultex.Client.auth(:app_id, {"boom", "whatever"}) == {:error, ["Bad response from vault [http://localhost:8200/v1/]", :econnrefused]}
   end
 
   test "Authentication of userpass is successful" do
@@ -39,7 +39,7 @@ defmodule VaultexTest do
   end
 
   test "Authentication of userpass causes an exception" do
-    assert Vaultex.Client.auth(:userpass, {"user", "boom"}) == {:error, ["Bad response from vault [http://localhost:8200/v1/]", "econnrefused"]}
+    assert Vaultex.Client.auth(:userpass, {"user", "boom"}) == {:error, ["Bad response from vault [http://localhost:8200/v1/]", :econnrefused]}
   end
 
   test "Authentication of ldap is successful" do
@@ -55,7 +55,7 @@ defmodule VaultexTest do
   end
 
   test "Authentication of ldap causes an exception" do
-    assert Vaultex.Client.auth(:ldap, {"user", "boom"}) == {:error, ["Bad response from vault [http://localhost:8200/v1/]", "econnrefused"]}
+    assert Vaultex.Client.auth(:ldap, {"user", "boom"}) == {:error, ["Bad response from vault [http://localhost:8200/v1/]", :econnrefused]}
   end
 
   test "Authentication of github_token is successful" do
@@ -71,7 +71,7 @@ defmodule VaultexTest do
   end
 
   test "Authentication of github_token causes an exception" do
-    assert Vaultex.Client.auth(:github, {"boom"}) == {:error, ["Bad response from vault [http://localhost:8200/v1/]", "econnrefused"]}
+    assert Vaultex.Client.auth(:github, {"boom"}) == {:error, ["Bad response from vault [http://localhost:8200/v1/]", :econnrefused]}
   end
 
   test "Authentication of token is successful" do
@@ -83,7 +83,11 @@ defmodule VaultexTest do
   end
 
   test "Authentication of token causes an exception" do
-    assert Vaultex.Client.auth(:token, {"boom"}) == {:error, ["Bad response from vault [http://localhost:8200/v1/]", "econnrefused"]}
+    assert Vaultex.Client.auth(:token, {"boom"}) == {:error, ["Bad response from vault [http://localhost:8200/v1/]", :econnrefused]}
+  end
+
+  test "Authentication of self signed ssl causes an exception" do
+    assert Vaultex.Client.auth(:token, {"ssl"}) == {:error, ["Bad response from vault [http://localhost:8200/v1/]", {:tls_alert, 'unknown ca'}]}
   end
 
   test "Read of valid secret key returns the correct value" do
@@ -103,7 +107,7 @@ defmodule VaultexTest do
   end
 
   test "Read of a secret key causes and exception" do
-    assert Vaultex.Client.read("secret/boom", :app_id, {"good", "whatever"}) == {:error, ["Bad response from vault [http://localhost:8200/v1/]", "econnrefused"]}
+    assert Vaultex.Client.read("secret/boom", :app_id, {"good", "whatever"}) == {:error, ["Bad response from vault [http://localhost:8200/v1/]", :econnrefused]}
   end
 
   test "Write of valid secret key returns :ok" do


### PR DESCRIPTION
Instead of trying to stringify error reason

    iex(2)> Vaultex.Client.auth(:token, {token})
    ** (exit) exited in: GenServer.call(:vaultex, {:auth, :token, {"0578e717-b211-9c2b-6784-0530564659d1"}}, 5000)
        ** (EXIT) an exception was raised:
            ** (Protocol.UndefinedError) protocol String.Chars not implemented for {:tls_alert, 'unknown ca'}. This protocol is implemented for: Atom, BitString, Date, DateTime, Decimal, Ecto.Date, Ecto.DateTime, Ecto.Time, Float, Integer, List, Mariaex.Query, NaiveDateTime, Time, URI, Version, Version.Requirement
                (elixir) /private/tmp/elixir-20180301-88311-1usjskt/elixir-1.6.2/lib/elixir/lib/string/chars.ex:3: String.Chars.impl_for!/1
                (elixir) /private/tmp/elixir-20180301-88311-1usjskt/elixir-1.6.2/lib/elixir/lib/string/chars.ex:22: String.Chars.to_string/1
                (vaultex) lib/vaultex/auth.ex:41: Vaultex.Auth.handle_response/2

Just return reason as is

    iex(2)> Vaultex.Client.auth(:token, {token})
    {:error,
     [
       "Bad response from vault [https://vault.example.com:8200/v1/]",
       {:tls_alert, 'unknown ca'}
     ]}