### PR TITLE
Add support for arbritrary auth methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ iex> Vaultex.Client.auth(:approle, {role_id, secret_id})
 
 iex> Vaultex.Client.auth(:token, {token})
 
+iex> Vaultex.Client.auth(:kubernetes, %{jwt: "jwt", role: "role"})
+
+iex> Vaultex.Client.auth(:radius, %{username: "user", password: "password"})
+
 ...
 iex> Vaultex.Client.read "secret/bar", :github, {github_token} #returns {:ok, %{"value" => bar"}}
 

--- a/test/vaultex_test.exs
+++ b/test/vaultex_test.exs
@@ -94,6 +94,20 @@ defmodule VaultexTest do
     assert Vaultex.Client.auth(:token, {"ssl"}) == {:error, ["Bad response from vault [http://localhost:8200/v1/]", {:tls_alert, 'unknown ca'}]}
   end
 
+  test "Authentication of arbitrary method and credentials" do
+    assert Vaultex.Client.auth(:kubernetes, %{jwt: "good", role: "demo"}) == {:ok, :authenticated}
+  end
+
+  test "Authentication of arbitrary method is unsuccessful" do
+    assert Vaultex.Client.auth(:kubernetes, %{jwt: "bad", role: "demo"}) == {:error, ["Not Authenticated"]}
+  end
+
+  test "Authentication with arbirary method username and password" do
+    assert Vaultex.Client.auth(:radius, %{username: "user", password: "good"}) == {:ok, :authenticated}
+
+    assert Vaultex.Client.auth(:plugin_defined, %{username: "user", password: "good"}) == {:ok, :authenticated}
+  end
+
   test "Read of valid secret key returns the correct value" do
     assert Vaultex.Client.read("secret/foo", :app_id, {"good", "whatever"}) == {:ok, %{"value" => "bar"}}
   end


### PR DESCRIPTION
Vault keeps adding auth methods and plugins can define infinitely more. 

This PR adds support for authentication with arbitrary methods and credentials. 

Any Vault auth plugin that supports authenticating via `POST auth/:method/login` or `POST auth/:method/login/:username` is supported.