### PR TITLE
Return full vault response from read

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,10 @@ iex> Vaultex.Client.auth(:kubernetes, %{jwt: "jwt", role: "role"})
 iex> Vaultex.Client.auth(:radius, %{username: "user", password: "password"})
 
 ...
-iex> Vaultex.Client.read "secret/bar", :github, {github_token} #returns {:ok, %{"data" => %{"value" => bar"}}}
+iex> Vaultex.Client.read "secret/bar", :github, {github_token} #returns {:ok, %{"value" => bar"}}
+
+...
+iex> Vaultex.Client.read_dynamic "secret/dynamic/bar", :github, {github_token} #returns {:ok, %{"data" => %{"value" => "bar"}, "lease_duration" => 60, "lease_id" => "secret/dynamic/foo/b4z", "renewable" => true}}
 
 ...
 iex> Vaultex.Client.write "secret/foo", %{"value" => "bar"}, :app_id, {app_id, user_id}

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ iex> Vaultex.Client.auth(:kubernetes, %{jwt: "jwt", role: "role"})
 iex> Vaultex.Client.auth(:radius, %{username: "user", password: "password"})
 
 ...
-iex> Vaultex.Client.read "secret/bar", :github, {github_token} #returns {:ok, %{"value" => bar"}}
+iex> Vaultex.Client.read "secret/bar", :github, {github_token} #returns {:ok, %{"data" => %{"value" => bar"}}}
 
 ...
 iex> Vaultex.Client.write "secret/foo", %{"value" => "bar"}, :app_id, {app_id, user_id}

--- a/lib/test_doubles/mock_httpoison.ex
+++ b/lib/test_doubles/mock_httpoison.ex
@@ -15,6 +15,13 @@ defmodule Vaultex.Test.TestDoubles.MockHTTPoison do
       url |> String.contains?("secret/foo") -> {:ok, %{status_code: status_code(url, url),
                                                       headers: [{"Location", redirect_url(url)}],
                                                       body: Poison.Encoder.encode(%{"data" => %{"value" => "bar"}},[])}}
+      url |> String.contains?("secret/dynamic/foo") -> {:ok, %{status_code: status_code(url, url),
+                                                       headers: [{"Location", redirect_url(url)}],
+                                                       body: Poison.Encoder.encode(%{"lease_id" => "secret/dynamic/foo/b4z",
+                                                                                    "lease_duration" => 60,
+                                                                                    "renewable" => true,
+                                                                                    "data" => %{"value" => "bar"}},[])}}
+      url |> String.contains?("secret/baz") -> {:ok, %{status_code: "whatever", body: Poison.Encoder.encode(%{"errors" => []},[])}}
       url |> String.contains?("secret/baz") -> {:ok, %{status_code: "whatever", body: Poison.Encoder.encode(%{"errors" => []},[])}}
       url |> String.contains?("secret/faz") -> {:ok, %{status_code: "whatever", body: Poison.Encoder.encode(%{"errors" => ["Not Authenticated"]},[])}}
       url |> String.contains?("secret/boom") -> {:error, %HTTPoison.Error{id: nil, reason: :econnrefused}}

--- a/lib/vaultex/client.ex
+++ b/lib/vaultex/client.ex
@@ -66,19 +66,19 @@ defmodule Vaultex.Client do
   ## Examples
 
       iex> Vaultex.Client.read("secret/foobar", :approle, {role_id, secret_id}, 5000)
-      {:ok, %{"value" => "bar"}}
+      {:ok, %{"data" => %{"value" => "bar"}}}
 
       iex> Vaultex.Client.read("secret/foo", :app_id, {app_id, user_id})
-      {:ok, %{"value" => "bar"}}
+      {:ok, %{"data" => %{"value" => "bar"}}}
 
       iex> Vaultex.Client.read("secret/baz", :userpass, {username, password})
       {:error, ["Key not found"]}
 
       iex> Vaultex.Client.read("secret/bar", :github, {github_token})
-      {:ok, %{"value" => "bar"}}
+      {:ok, %{"data" => %{"value" => "bar"}}}
 
       iex> Vaultex.Client.read("secret/bar", :plugin_defined_auth, credentials)
-      {:ok, %{"value" => "bar"}}
+      {:ok, %{"data" => %{"value" => "bar"}}}
   """
   def read(key, auth_method, credentials, timeout \\ 5000) do
     response = read(key, timeout)

--- a/lib/vaultex/read.ex
+++ b/lib/vaultex/read.ex
@@ -11,9 +11,9 @@ defmodule Vaultex.Read do
 
   defp handle_response({:ok, response}, state) do
     case response.body |> Poison.Parser.parse! do
-      %{"data" => data} -> {:reply, {:ok, data}, state}
       %{"errors" => []} -> {:reply, {:error, ["Key not found"]}, state}
       %{"errors" => messages} -> {:reply, {:error, messages}, state}
+      parsed_resp -> {:reply, {:ok, parsed_resp}, state}
     end
   end
 

--- a/test/vaultex_test.exs
+++ b/test/vaultex_test.exs
@@ -109,15 +109,15 @@ defmodule VaultexTest do
   end
 
   test "Read of valid secret key returns the correct value" do
-    assert Vaultex.Client.read("secret/foo", :app_id, {"good", "whatever"}) == {:ok, %{"value" => "bar"}}
+    assert Vaultex.Client.read("secret/foo", :app_id, {"good", "whatever"}) == {:ok, %{"data" => %{"value" => "bar"}}}
   end
 
   test "Read of valid secret key with timeout returns the correct value" do
-    assert Vaultex.Client.read("secret/foo", :app_id, {"good", "whatever"}, 5000) == {:ok, %{"value" => "bar"}}
+    assert Vaultex.Client.read("secret/foo", :app_id, {"good", "whatever"}, 5000) == {:ok, %{"data" => %{"value" => "bar"}}}
   end
 
   test "Read of valid secret key requiring redirect returns the correct value" do
-    assert Vaultex.Client.read("secret/foo/redirects", :app_id, {"good", "whatever"}) == {:ok, %{"value" => "bar"}}
+    assert Vaultex.Client.read("secret/foo/redirects", :app_id, {"good", "whatever"}) == {:ok, %{"data" => %{"value" => "bar"}}}
   end
 
   test "Read of non existing secret key returns error" do

--- a/test/vaultex_test.exs
+++ b/test/vaultex_test.exs
@@ -109,19 +109,19 @@ defmodule VaultexTest do
   end
 
   test "Read of valid secret key returns the correct value" do
-    assert Vaultex.Client.read("secret/foo", :app_id, {"good", "whatever"}) == {:ok, %{"data" => %{"value" => "bar"}}}
+    assert Vaultex.Client.read("secret/foo", :app_id, {"good", "whatever"}) == {:ok, %{"value" => "bar"}}
   end
 
   test "Read of valid secret key with timeout returns the correct value" do
-    assert Vaultex.Client.read("secret/foo", :app_id, {"good", "whatever"}, 5000) == {:ok, %{"data" => %{"value" => "bar"}}}
+    assert Vaultex.Client.read("secret/foo", :app_id, {"good", "whatever"}, 5000) == {:ok, %{"value" => "bar"}}
   end
 
   test "Read of valid secret key requiring redirect returns the correct value" do
-    assert Vaultex.Client.read("secret/foo/redirects", :app_id, {"good", "whatever"}) == {:ok, %{"data" => %{"value" => "bar"}}}
+    assert Vaultex.Client.read("secret/foo/redirects", :app_id, {"good", "whatever"}) == {:ok, %{"value" => "bar"}}
   end
 
   test "Read of valid dynamic secret returns the correct value" do
-    assert Vaultex.Client.read("secret/dynamic/foo", :app_id, {"good", "whatever"}) == {:ok, %{"lease_id" => "secret/dynamic/foo/b4z",
+    assert Vaultex.Client.read_dynamic("secret/dynamic/foo", :app_id, {"good", "whatever"}) == {:ok, %{"lease_id" => "secret/dynamic/foo/b4z",
                                                                                               "lease_duration" => 60,
                                                                                               "renewable" => true,
                                                                                               "data" => %{"value" => "bar"}}}

--- a/test/vaultex_test.exs
+++ b/test/vaultex_test.exs
@@ -120,6 +120,13 @@ defmodule VaultexTest do
     assert Vaultex.Client.read("secret/foo/redirects", :app_id, {"good", "whatever"}) == {:ok, %{"data" => %{"value" => "bar"}}}
   end
 
+  test "Read of valid dynamic secret returns the correct value" do
+    assert Vaultex.Client.read("secret/dynamic/foo", :app_id, {"good", "whatever"}) == {:ok, %{"lease_id" => "secret/dynamic/foo/b4z",
+                                                                                              "lease_duration" => 60,
+                                                                                              "renewable" => true,
+                                                                                              "data" => %{"value" => "bar"}}}
+  end
+
   test "Read of non existing secret key returns error" do
     assert Vaultex.Client.read("secret/baz", :app_id, {"good", "whatever"}) == {:error, ["Key not found"]}
   end


### PR DESCRIPTION
So the current way of just returning data is not particularly compatible when reading dynamic secrets, as the info on the lease such as duration and the lease_id, is returned from vault outside of "data". 

Here's an example of what reading a dynamic secret looks like:
`{"request_id":"f8702666-b506-ae5c-7cd4-bd108f896d20","lease_id":"rabbitmq/creds/rabbitservice/57WLzNYd393qg1hCCrO82fdD","renewable":true,"lease_duration":360000,"data":{"password":"ded00657-a106-70e5-f170-4dbf87ee7066","username":"userpass-rabbitservice-241a2127-3895-e669-247c-b209cc649ff7"},"wrap_info":null,"warnings":null,"auth":null}`

So this change changes read to return the full parsed response so the user can pull out the lease info if needed. 

I know this fundamentally changes the API of read, but I believe this change is needed to make sure vaultex can work with dynamic secrets. 