### PR TITLE
Add renew endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ iex> Vaultex.Client.read "secret/bar", :github, {github_token} #returns {:ok, %{
 iex> Vaultex.Client.read_dynamic "secret/dynamic/bar", :github, {github_token} #returns {:ok, %{"data" => %{"value" => "bar"}, "lease_duration" => 60, "lease_id" => "secret/dynamic/foo/b4z", "renewable" => true}}
 
 ...
+iex> Vaultex.Client.renew_lease("secret/dynamic/foo/b4z", 100, :github, {github_token}) #returns {:ok, %{"lease_id" => "secret/dynamic/foo/b4z", "lease_duration" => 160, "renewable" => true}}
+
+...
 iex> Vaultex.Client.write "secret/foo", %{"value" => "bar"}, :app_id, {app_id, user_id}
 
 ...

--- a/lib/test_doubles/mock_httpoison.ex
+++ b/lib/test_doubles/mock_httpoison.ex
@@ -32,6 +32,9 @@ defmodule Vaultex.Test.TestDoubles.MockHTTPoison do
   def request(:put, url, _params, _, _) do
     cond do
       String.ends_with?(url, "secret/foo/withresponse") -> {:ok, %{status_code: 200, body: Poison.Encoder.encode(%{"data" => %{"value" => "bar"}},[])}}
+      String.contains?(url, "sys/leases/renew") -> {:ok, %{status_code: 200, body: Poison.Encoder.encode(%{"lease_id" => "secret/dynamic/foo/b4z",
+                                                                                                          "lease_duration" => 160,
+                                                                                                          "renewable" => true},[])}}
       String.ends_with?(url, "secret/foo") -> {:ok, %{status_code: 204, body: ""}}
       String.ends_with?(url, "secret/foo/redirects") -> {:ok, %{status_code: 307, body: "", headers: [{"Location", "secret/foo"}]}}
       :else -> raise "Unmatched url #{url}"

--- a/lib/vaultex/leases.ex
+++ b/lib/vaultex/leases.ex
@@ -1,0 +1,26 @@
+defmodule Vaultex.Leases do
+  def handle(:renew, lease, increment, state = %{token: token}) do
+    body = %{"lease_id" => lease, "increment" => increment}
+    request(:put, "#{state.url}/sys/leases/renew", body, [{"Content-Type", "application/json"}, {"X-Vault-Token", token}])
+    |> handle_response(state)
+  end
+
+  def handle(:renew, _lease, _increment, state = %{}) do
+    {:reply, {:error, ["Not Authenticated"]}, state}
+  end
+
+  defp handle_response({:ok, response}, state) do
+    case response.body |> Poison.Parser.parse! do
+      %{"errors" => messages} -> {:reply, {:error, messages}, state}
+      parsed_resp -> {:reply, {:ok, parsed_resp}, state}
+    end
+  end
+
+  defp handle_response({_, %HTTPoison.Error{reason: reason}}, state) do
+    {:reply, {:error, ["Bad response from vault [#{state.url}]", reason]}, state}
+  end
+
+  defp request(method, url, body, headers) do
+    Vaultex.RedirectableRequests.request(method, url, body, headers)
+  end
+end

--- a/lib/vaultex/leases.ex
+++ b/lib/vaultex/leases.ex
@@ -1,7 +1,7 @@
 defmodule Vaultex.Leases do
   def handle(:renew, lease, increment, state = %{token: token}) do
     body = %{"lease_id" => lease, "increment" => increment}
-    request(:put, "#{state.url}/sys/leases/renew", body, [{"Content-Type", "application/json"}, {"X-Vault-Token", token}])
+    request(:put, "#{state.url}sys/leases/renew", body, [{"Content-Type", "application/json"}, {"X-Vault-Token", token}])
     |> handle_response(state)
   end
 

--- a/test/vaultex_test.exs
+++ b/test/vaultex_test.exs
@@ -139,6 +139,12 @@ defmodule VaultexTest do
     assert Vaultex.Client.read("secret/boom", :app_id, {"good", "whatever"}) == {:error, ["Bad response from vault [http://localhost:8200/v1/]", :econnrefused]}
   end
 
+  test "Renew a lease" do
+    assert Vaultex.Client.renew_lease("secret/dynamic/foo/b4z", 100, :app_id, {"good", "whatever"}) == {:ok, %{"lease_id" => "secret/dynamic/foo/b4z",
+                                                                        "lease_duration" => 160,
+                                                                        "renewable" => true}}
+  end
+
   test "Write of valid secret key returns :ok" do
     assert Vaultex.Client.write("secret/foo", %{"value" => "bar"}, :app_id, {"good", "whatever"}) == :ok
   end


### PR DESCRIPTION
So too now add-on to more dynamic secrets support, dynamic secrets come with leases that you can renew when they're about to expire, so this just adds that endpoint to the client. 