### PR TITLE
fix doc example typo

### DIFF
--- a/lib/vaultex/client.ex
+++ b/lib/vaultex/client.ex
@@ -30,7 +30,7 @@ defmodule Vaultex.Client do
 
   ## Examples
 
-      iex> Vaultex.Client.auth(:approle {role_id, secret_id}, 5000)
+      iex> Vaultex.Client.auth(:approle, {role_id, secret_id}, 5000)
       {:ok, :authenticated}
 
       iex> Vaultex.Client.auth(:app_id, {app_id, user_id})


### PR DESCRIPTION
Prior to this commit one of the documentation examples for
`Vaultex.Client.auth/3` was missing a comma. This commit ensures the
example is representative of the code that must be run.