### PR TITLE
display warnings from 404

### DIFF
--- a/lib/test_doubles/mock_httpoison.ex
+++ b/lib/test_doubles/mock_httpoison.ex
@@ -20,6 +20,7 @@ defmodule Vaultex.Test.TestDoubles.MockHTTPoison do
                                                                                     "lease_duration" => 60,
                                                                                     "renewable" => true,
                                                                                     "data" => %{"value" => "bar"}},[])}}
+      url |> String.contains?("secret/coffee") -> {:ok, %{status_code: 404, body: Poison.encode!(%{warnings: ["bad path"]})}}
       url |> String.contains?("secret/baz") -> {:ok, %{status_code: "whatever", body: Poison.encode!(%{"errors" => []},[])}}
       url |> String.contains?("secret/baz") -> {:ok, %{status_code: "whatever", body: Poison.encode!(%{"errors" => []},[])}}
       url |> String.contains?("secret/faz") -> {:ok, %{status_code: "whatever", body: Poison.encode!(%{"errors" => ["Not Authenticated"]},[])}}

--- a/lib/vaultex/read.ex
+++ b/lib/vaultex/read.ex
@@ -8,11 +8,11 @@ defmodule Vaultex.Read do
     {:reply, {:error, ["Not Authenticated"]}, state}
   end
 
-
   defp handle_response({:ok, response}, state) do
     case response.body |> Poison.decode!() do
       %{"errors" => []} -> {:reply, {:error, ["Key not found"]}, state}
       %{"errors" => messages} -> {:reply, {:error, messages}, state}
+      %{"warnings" => messages} -> {:reply, {:ok, %{"warnings" => messages}}, state}
       parsed_resp -> {:reply, {:ok, parsed_resp}, state}
     end
   end

--- a/test/vaultex_test.exs
+++ b/test/vaultex_test.exs
@@ -143,6 +143,10 @@ defmodule VaultexTest do
     assert Vaultex.Client.read("secret/baz", :app_id, {"good", "whatever"}) == {:error, ["Key not found"]}
   end
 
+  test "Read of secret v2 key at v1 path returns warning" do
+    assert Vaultex.Client.read("secret/coffee", :app_id, {"good", "whatever"}) == {:ok, %{"warnings" => ["bad path"]}}
+  end
+
   test "Read of a secret key given bad authentication returns error" do
     assert Vaultex.Client.read("secret/faz", :app_id, {"bad", "whatever"}) == {:error, ["Not Authenticated"]}
   end


### PR DESCRIPTION
Hello,

I was trying out the library with Vault 1.3.2 and after firing off:
```elixir
iex(9)>  Vaultex.Client.read("secret/coffee", :token, {t})                                                                                 
{:ok, nil} 
```

I didn't understand it since the cli worked - after a bit of digging I saw this in the poison response
```elixir
 %HTTPoison.Response{                                                                                                                      
   body: "{\"warnings\":[\"Invalid path for a versioned K/V secrets engine. See the API docs for the appropriate API endpoints to 
use. If using the Vault CLI, use 'vault kv get' for this operation.\"]}", status_code: 404}  
```

So I guess that if the KV is v2 the path is `secret/data/coffee` https://www.vaultproject.io/api/secret/kv/kv-v2.html#read-secret-version

I think it would be helpful to display warnings, especially for a 404. I don't know if this is the way you want to go - perhaps a v2 read method wold work better? Anyway added a test and a function clause to highlight one possible solution. I don't know if we want to have a separate `case` in the existing function instead. Currently the way it's written 404's with errors and no warnings would pass through even though current tests pass. Feedback greatly appreciated.