### PR TITLE
poison should be listed as runtime dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Vaultex.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger, :httpoison],
+    [extra_applications: [:logger, :httpoison, :poison],
      mod: {Vaultex, []}]
   end
 


### PR DESCRIPTION
Currently if we do `mix release` on a project which includes vaultex as a dependency, poison is not included in the release it is not considered a runtime dependency by Mix. This PR resolves the issue.

See https://www.amberbit.com/blog/2019/8/23/mix-release-and-missing-dependencies/
