### PR TITLE
Do not consider empty warnings or errors as a problem

### DIFF
--- a/lib/test_doubles/mock_httpoison.ex
+++ b/lib/test_doubles/mock_httpoison.ex
@@ -20,6 +20,12 @@ defmodule Vaultex.Test.TestDoubles.MockHTTPoison do
                                                                                     "lease_duration" => 60,
                                                                                     "renewable" => true,
                                                                                     "data" => %{"value" => "bar"}},[])}}
+      url |> String.contains?("secret/empty_warning") -> {:ok, %{status_code: status_code(url, url),
+                                                      headers: [{"Location", redirect_url(url)}],
+                                                      body: Poison.encode!(%{"data" => %{"value" => "empty_warning"}, "warnings" => nil},[])}}
+      url |> String.contains?("secret/empty_error") -> {:ok, %{status_code: status_code(url, url),
+                                                      headers: [{"Location", redirect_url(url)}],
+                                                      body: Poison.encode!(%{"data" => %{"value" => "empty_error"}, "errors" => nil},[])}}
       url |> String.contains?("secret/coffee") -> {:ok, %{status_code: 404, body: Poison.encode!(%{warnings: ["bad path"]})}}
       url |> String.contains?("secret/baz") -> {:ok, %{status_code: "whatever", body: Poison.encode!(%{"errors" => []},[])}}
       url |> String.contains?("secret/baz") -> {:ok, %{status_code: "whatever", body: Poison.encode!(%{"errors" => []},[])}}

--- a/lib/vaultex/read.ex
+++ b/lib/vaultex/read.ex
@@ -11,8 +11,8 @@ defmodule Vaultex.Read do
   defp handle_response({:ok, response}, state) do
     case response.body |> Poison.decode!() do
       %{"errors" => []} -> {:reply, {:error, ["Key not found"]}, state}
-      %{"errors" => messages} -> {:reply, {:error, messages}, state}
-      %{"warnings" => messages} -> {:reply, {:ok, %{"warnings" => messages}}, state}
+      %{"errors" => messages} when not is_nil(messages) -> {:reply, {:error, messages}, state}
+      %{"warnings" => messages} when not is_nil(messages) -> {:reply, {:ok, %{"warnings" => messages}}, state}
       parsed_resp -> {:reply, {:ok, parsed_resp}, state}
     end
   end

--- a/test/vaultex_test.exs
+++ b/test/vaultex_test.exs
@@ -139,20 +139,20 @@ defmodule VaultexTest do
                                                                                               "data" => %{"value" => "bar"}}}
   end
 
+  test "Read of valid secret with empty warnings" do
+    assert Vaultex.Client.read("secret/empty_warning", :app_id, {"good", "whatever"}) == {:ok, %{"value" => "empty_warning"}}
+  end
+
+  test "Read of valid secret with empty errors" do
+    assert Vaultex.Client.read("secret/empty_error", :app_id, {"good", "whatever"}) == {:ok, %{"value" => "empty_error"}}
+  end
+
   test "Read of non existing secret key returns error" do
     assert Vaultex.Client.read("secret/baz", :app_id, {"good", "whatever"}) == {:error, ["Key not found"]}
   end
 
   test "Read of secret v2 key at v1 path returns warning" do
     assert Vaultex.Client.read("secret/coffee", :app_id, {"good", "whatever"}) == {:ok, %{"warnings" => ["bad path"]}}
-  end
-
-  test "Read of a secret key given bad authentication returns error" do
-    assert Vaultex.Client.read("secret/faz", :app_id, {"bad", "whatever"}) == {:error, ["Not Authenticated"]}
-  end
-
-  test "Read of a secret key causes and exception" do
-    assert Vaultex.Client.read("secret/boom", :app_id, {"good", "whatever"}) == {:error, ["Bad response from vault [http://localhost:8200/v1/]", :econnrefused]}
   end
 
   test "Renew a lease" do


### PR DESCRIPTION
While trying to upgrade to poison 4, I noticed that no secrets are being returned from vault, because an empty warning `%{"warning" => nil}` comes in the response
This hijacks the results, thinking that there was a real warning
