### PR TITLE
#42 - fix AWS IAM header missing a dash

### DIFF
--- a/lib/vaultex/aws_iam.ex
+++ b/lib/vaultex/aws_iam.ex
@@ -38,5 +38,5 @@ defmodule Vaultex.Auth.AWSIAM do
 
   defp maybe_add_server(headers, nil), do: headers
   defp maybe_add_server(headers, server),
-    do: [{"X-Vault-awsiam-Server-Id", server} | headers]
+    do: [{"X-Vault-AWS-IAM-Server-Id", server} | headers]
 end


### PR DESCRIPTION
Fixes the missing dash in the AWS IAM server header.